### PR TITLE
plr.Stream position must be set to 0

### DIFF
--- a/Src/DKLang.pas
+++ b/Src/DKLang.pas
@@ -2558,7 +2558,11 @@ uses TypInfo, Math, System.Types;
             dklrkResName: Result.Text_LoadFromResource(plr.Instance, plr.wsName);
             dklrkResID:   Result.Text_LoadFromResource(plr.Instance, plr.iResID);
             dklrkFile:    Result.Text_LoadFromFile(plr.wsName);
-            dklrkStream:  Result.Text_LoadFromStream(plr.Stream);
+            dklrkStream:  
+              begin
+                plr.Stream.Position := 0;
+                Result.Text_LoadFromStream(plr.Stream);
+              end;
           end;
         except
           Result.Free;


### PR DESCRIPTION
TDKLanguageManager can not translate forms created at runtime. Becouse plr.Stream position is at the end of the Stream. It must be set to 0 to be read at a later time.
