### PR TITLE
Bug fix: Before, working only UCS-2LE file format for lang files. Now, w...

### DIFF
--- a/DKLang.pas
+++ b/DKLang.pas
@@ -1188,7 +1188,8 @@ var
        // Remember the original stream position
       i64Pos := Stream.Position;
        // Determine whether this is an Unicode source (BEFORE any reading is done)
-      FIsStreamUnicode := AutoDetectCharacterSet(Stream)=csUnicode;
+
+      FIsStreamUnicode := AutoDetectCharacterSet(Stream)<>csAnsi;
       Stream.Position := i64Pos;
        // Load the stream contents into the list
       List.LoadFromStream(Stream);


### PR DESCRIPTION
Bug fix: not work UTF8.

Before, working only UCS-2LE file format for lang files. (Standard examples not worked too)

Now, work all - and UTF8 too.
