### PR TITLE
Search constants, XE4 package, enabled TABing.

### DIFF
--- a/Packages/dcldklang180_XE4.dpk
+++ b/Packages/dcldklang180_XE4.dpk
@@ -1,0 +1,44 @@
+package dcldklang180_XE4;
+
+{$R *.res}
+{$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
+{$ALIGN 8}
+{$ASSERTIONS ON}
+{$BOOLEVAL OFF}
+{$DEBUGINFO OFF}
+{$EXTENDEDSYNTAX ON}
+{$IMPORTEDDATA ON}
+{$IOCHECKS ON}
+{$LOCALSYMBOLS ON}
+{$LONGSTRINGS ON}
+{$OPENSTRINGS ON}
+{$OPTIMIZATION OFF}
+{$OVERFLOWCHECKS OFF}
+{$RANGECHECKS OFF}
+{$REFERENCEINFO ON}
+{$SAFEDIVIDE OFF}
+{$STACKFRAMES ON}
+{$TYPEDADDRESS OFF}
+{$VARSTRINGCHECKS ON}
+{$WRITEABLECONST OFF}
+{$MINENUMSIZE 1}
+{$IMAGEBASE $400000}
+{$DEFINE DEBUG}
+{$ENDIF IMPLICITBUILDING}
+{$DESCRIPTION 'DKLang Localization Package - IDE Tools'}
+{$DESIGNONLY}
+{$IMPLICITBUILD ON}
+
+
+requires
+  designide,
+  dklang180_XE4;
+
+contains
+  DKL_ResFile in '..\src\DKL_ResFile.pas',
+  DKL_Expt in '..\src\DKL_Expt.pas',
+  DKL_ConstEditor in '..\src\DKL_ConstEditor.pas' {dDKL_ConstEditor},
+  DKLangReg in '..\src\DKLangReg.pas',
+  DKL_StorageEditor in '..\src\DKL_StorageEditor.pas' {DKLangTranslationStorageEditor};
+
+end.

--- a/Src/DKL_ConstEditor.dfm
+++ b/Src/DKL_ConstEditor.dfm
@@ -4,52 +4,73 @@ object dDKL_ConstEditor: TdDKL_ConstEditor
   ActiveControl = gMain
   BorderIcons = [biSystemMenu, biMaximize]
   Caption = 'DKLang Constant Editor'
-  ClientHeight = 435
-  ClientWidth = 592
+  ClientHeight = 875
+  ClientWidth = 1066
   Color = clBtnFace
-  Constraints.MinHeight = 300
-  Constraints.MinWidth = 600
+  Constraints.MinHeight = 415
+  Constraints.MinWidth = 831
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
-  Font.Height = -11
+  Font.Height = -16
   Font.Name = 'MS Shell Dlg 2'
   Font.Style = []
   OldCreateOrder = False
   Position = poScreenCenter
+  OnCreate = FormCreate
   DesignSize = (
-    592
-    435)
-  PixelsPerInch = 96
-  TextHeight = 13
+    1066
+    875)
+  PixelsPerInch = 130
+  TextHeight = 19
   object lCount: TLabel
-    Left = 8
-    Top = 408
-    Width = 43
-    Height = 13
+    Left = 11
+    Top = 838
+    Width = 63
+    Height = 19
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
     Anchors = [akLeft, akBottom]
     Caption = '<count>'
+    ExplicitTop = 565
   end
   object lDeleteHint: TLabel
-    Left = 8
-    Top = 368
-    Width = 213
-    Height = 13
+    Left = 11
+    Top = 783
+    Width = 306
+    Height = 19
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
     Anchors = [akLeft, akBottom]
     Caption = 'Use Ctrl+Delete to delete the current entry.'
+    ExplicitTop = 510
+  end
+  object lblSearchPos: TLabel
+    Left = 437
+    Top = 11
+    Width = 123
+    Height = 19
+    Caption = '<SEARCH_POS>'
   end
   object gMain: TStringGrid
-    Left = 8
-    Top = 8
-    Width = 577
-    Height = 357
+    Left = 12
+    Top = 38
+    Width = 1045
+    Height = 737
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
+    Margins.Bottom = 4
     Anchors = [akLeft, akTop, akRight, akBottom]
     ColCount = 2
-    DefaultRowHeight = 18
+    DefaultRowHeight = 22
     FixedCols = 0
     RowCount = 2
     Options = [goFixedVertLine, goFixedHorzLine, goVertLine, goHorzLine, goColSizing, goEditing, goAlwaysShowEditor, goThumbTracking]
     ScrollBars = ssVertical
     TabOrder = 0
+    OnDrawCell = gMainDrawCell
     OnKeyDown = gMainKeyDown
     OnMouseUp = gMainMouseUp
     OnSelectCell = gMainSelectCell
@@ -58,10 +79,14 @@ object dDKL_ConstEditor: TdDKL_ConstEditor
       284)
   end
   object bOK: TButton
-    Left = 188
-    Top = 404
-    Width = 75
-    Height = 23
+    Left = 506
+    Top = 832
+    Width = 104
+    Height = 32
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
+    Margins.Bottom = 4
     Anchors = [akRight, akBottom]
     Caption = '&OK'
     Default = True
@@ -69,10 +94,14 @@ object dDKL_ConstEditor: TdDKL_ConstEditor
     OnClick = bOKClick
   end
   object bCancel: TButton
-    Left = 268
-    Top = 404
-    Width = 75
-    Height = 23
+    Left = 617
+    Top = 832
+    Width = 104
+    Height = 32
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
+    Margins.Bottom = 4
     Anchors = [akRight, akBottom]
     Cancel = True
     Caption = '&Cancel'
@@ -80,30 +109,42 @@ object dDKL_ConstEditor: TdDKL_ConstEditor
     TabOrder = 3
   end
   object bLoad: TButton
-    Left = 428
-    Top = 404
-    Width = 75
-    Height = 23
+    Left = 839
+    Top = 832
+    Width = 103
+    Height = 32
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
+    Margins.Bottom = 4
     Anchors = [akRight, akBottom]
     Caption = '&Load...'
     TabOrder = 5
     OnClick = bLoadClick
   end
   object bSave: TButton
-    Left = 508
-    Top = 404
-    Width = 75
-    Height = 23
+    Left = 949
+    Top = 832
+    Width = 104
+    Height = 32
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
+    Margins.Bottom = 4
     Anchors = [akRight, akBottom]
     Caption = '&Save...'
     TabOrder = 6
     OnClick = bSaveClick
   end
   object cbSaveToLangSource: TCheckBox
-    Left = 8
-    Top = 384
-    Width = 573
-    Height = 17
+    Left = 11
+    Top = 805
+    Width = 1039
+    Height = 23
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
+    Margins.Bottom = 4
     Anchors = [akLeft, akRight, akBottom]
     Caption = 
       '&Also save the constants into the project language source file (' +
@@ -111,13 +152,48 @@ object dDKL_ConstEditor: TdDKL_ConstEditor
     TabOrder = 1
   end
   object bErase: TButton
-    Left = 348
-    Top = 404
-    Width = 75
-    Height = 23
+    Left = 728
+    Top = 832
+    Width = 104
+    Height = 32
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
+    Margins.Bottom = 4
     Anchors = [akRight, akBottom]
     Caption = '&Erase'
     TabOrder = 4
     OnClick = bEraseClick
+  end
+  object edtSearch: TEdit
+    Left = 11
+    Top = 7
+    Width = 214
+    Height = 27
+    ParentShowHint = False
+    ShowHint = False
+    TabOrder = 7
+    TextHint = 'Search...'
+    OnChange = edtSearchChange
+  end
+  object btnGotoFirstMatch: TButton
+    Left = 231
+    Top = 7
+    Width = 109
+    Height = 27
+    Caption = '<- &Previous'
+    TabOrder = 8
+    TabStop = False
+    OnClick = btnGotoFirstMatchClick
+  end
+  object btnGotoNextMatch: TButton
+    Left = 346
+    Top = 7
+    Width = 85
+    Height = 27
+    Caption = '&Next ->'
+    TabOrder = 9
+    TabStop = False
+    OnClick = btnGotoNextMatchClick
   end
 end


### PR DESCRIPTION
- Added the ability to **search** for constant names and values in the 'Constants Editor' form. 
 - Added the .dpk file for Delphi **XE4**.
- Allow pressing the TAB key to jump to the next cell when editing constants.

Screenshot is below, although it doesn't show the benefits of the new searching feature, unless you have hundreds of constants in your project:
![2017-10-22_21h31_48](https://user-images.githubusercontent.com/541197/31862450-6b532cd6-b770-11e7-9793-78070782ceb3.png)